### PR TITLE
Flexible root volume and stability changes

### DIFF
--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,5 +1,4 @@
-environment/terraform.tfstate.backup
-environment/terraform.tfstate
+environment/terraform.tfstate*
 environment/.terraform/*
 environment/.terraform.lock.hcl
 environment/port_*.json

--- a/terraform/environment/provider.tf
+++ b/terraform/environment/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     openstack = {
       source  = "terraform-provider-openstack/openstack"
-      version = "1.54.1"
+      version = "2.0.0"
     }
   }
 }

--- a/terraform/environment/single.tf.example
+++ b/terraform/environment/single.tf.example
@@ -6,6 +6,7 @@ module "MyVM" {
   nginx_enabled = false #Webserver, set to true if you need port 80 exposed
   nfs_enabled   = false #Only set true if you requested access
   vsc_enabled   = false #Only set true if you requested access
+  is_windows = false
 }
 output "MyVM" {
   value = module.MyVM.Connections

--- a/terraform/environment/volume.example
+++ b/terraform/environment/volume.example
@@ -6,6 +6,7 @@ module "MyVM" {
   nginx_enabled = false #Webserver, set to true if you need port 80 exposed
   nfs_enabled   = false #Only set true if you requested access
   vsc_enabled   = false #Only set true if you requested access
+  is_windows = false
   volumes = {
     vol1 = {
         size = 10

--- a/terraform/modules/multi_instance/main.tf
+++ b/terraform/modules/multi_instance/main.tf
@@ -9,6 +9,7 @@ module "main" {
   access_key    = var.access_key
   vsc_enabled   = var.public_vsc_enabled
   playbook_url  = var.playbook_url
+  is_windows = false
 }
 module "private" {
   count        = var.private_count
@@ -20,6 +21,7 @@ module "private" {
   project_name = var.project_name
   access_key   = var.access_key
   public       = false
+  is_windows = false
 }
 output "main" {
   value = module.main.Connections

--- a/terraform/modules/multi_instance/provider.tf
+++ b/terraform/modules/multi_instance/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     openstack = {
       source  = "terraform-provider-openstack/openstack"
-      version = "1.54.1"
+      version = "2.0.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/terraform/modules/nfs/provider.tf
+++ b/terraform/modules/nfs/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     openstack = {
       source  = "terraform-provider-openstack/openstack"
-      version = "1.54.1"
+      version = "2.0.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/terraform/modules/single_instance/data.tf
+++ b/terraform/modules/single_instance/data.tf
@@ -5,12 +5,12 @@ locals {
     ssh  = jsondecode(shell_script.port_ssh.output["ports"])[0]
     http = var.nginx_enabled ? jsondecode(shell_script.port_http[0].output["ports"])[0] : null
   }
-  is_windows        = var.is_windows ? var.is_windows : contains(["Windows10", "Windows-11"], var.image_name)
+  is_windows        = var.is_windows != "default" ? var.is_windows : contains(["Windows10", "Windows-11"], var.image_name)
   ssh_internal_port = local.is_windows ? 3389 : 22
   project_name      = var.project_name == "default" ? data.shell_script.project.output["Name"] : var.project_name
   access_key        = var.access_key == "default" ? data.shell_script.access_key.output["Name"] : var.access_key
   disk_var          = var.rootdisk_size == "default" ? data.openstack_compute_flavor_v2.flavor.disk : var.rootdisk_size
-  disk_size         = local.is_windows ? max(local.disk_var,60) : local.disk_var
+  disk_size         = local.is_windows? max(local.disk_var,60) : local.disk_var
 }
 
 # UUID for this "instance of the module" rather than depending on a changeable instance ID

--- a/terraform/modules/single_instance/data.tf
+++ b/terraform/modules/single_instance/data.tf
@@ -9,6 +9,8 @@ locals {
   ssh_internal_port = local.is_windows ? 3389 : 22
   project_name      = var.project_name == "default" ? data.shell_script.project.output["Name"] : var.project_name
   access_key        = var.access_key == "default" ? data.shell_script.access_key.output["Name"] : var.access_key
+  disk_var          = var.rootdisk_size == "default" ? data.openstack_compute_flavor_v2.flavor.disk : var.rootdisk_size
+  disk_size         = local.is_windows ? max(local.disk_var,60) : local.disk_var
 }
 resource "shell_script" "port_ssh" {
   environment = {

--- a/terraform/modules/single_instance/data.tf
+++ b/terraform/modules/single_instance/data.tf
@@ -5,7 +5,7 @@ locals {
     ssh  = jsondecode(shell_script.port_ssh.output["ports"])[0]
     http = var.nginx_enabled ? jsondecode(shell_script.port_http[0].output["ports"])[0] : null
   }
-  is_windows        = contains(["Windows10", "Windows-11"], var.image_name)
+  is_windows        = var.is_windows ? var.is_windows : contains(["Windows10", "Windows-11"], var.image_name)
   ssh_internal_port = local.is_windows ? 3389 : 22
   project_name      = var.project_name == "default" ? data.shell_script.project.output["Name"] : var.project_name
   access_key        = var.access_key == "default" ? data.shell_script.access_key.output["Name"] : var.access_key

--- a/terraform/modules/single_instance/data.tf
+++ b/terraform/modules/single_instance/data.tf
@@ -5,12 +5,11 @@ locals {
     ssh  = jsondecode(shell_script.port_ssh.output["ports"])[0]
     http = var.nginx_enabled ? jsondecode(shell_script.port_http[0].output["ports"])[0] : null
   }
-  is_windows        = var.is_windows != "default" ? var.is_windows : contains(["Windows10", "Windows-11"], var.image_name)
-  ssh_internal_port = local.is_windows ? 3389 : 22
+  ssh_internal_port = var.is_windows ? 3389 : 22
   project_name      = var.project_name == "default" ? data.shell_script.project.output["Name"] : var.project_name
   access_key        = var.access_key == "default" ? data.shell_script.access_key.output["Name"] : var.access_key
   disk_var          = var.rootdisk_size == "default" ? data.openstack_compute_flavor_v2.flavor.disk : var.rootdisk_size
-  disk_size         = local.is_windows? max(local.disk_var,60) : local.disk_var
+  disk_size         = var.is_windows ? max(local.disk_var,60) : local.disk_var
 }
 
 # UUID for this "instance of the module" rather than depending on a changeable instance ID
@@ -95,7 +94,7 @@ data "openstack_networking_floatingip_v2" "public" {
   pool = data.openstack_networking_network_v2.public.id
 }
 resource "random_string" "winpass" {
-  count   = local.is_windows ? 1 : 0
+  count   = var.is_windows ? 1 : 0
   length  = 16
   special = false
 }

--- a/terraform/modules/single_instance/data.tf
+++ b/terraform/modules/single_instance/data.tf
@@ -12,20 +12,25 @@ locals {
   disk_var          = var.rootdisk_size == "default" ? data.openstack_compute_flavor_v2.flavor.disk : var.rootdisk_size
   disk_size         = local.is_windows ? max(local.disk_var,60) : local.disk_var
 }
+
+# UUID for this "instance of the module" rather than depending on a changeable instance ID
+resource "random_uuid" "uuid" {
+  
+}
 resource "shell_script" "port_ssh" {
   environment = {
     "IP_ID"      = data.openstack_networking_floatingip_v2.public.id
     "PORT_COUNT" = 1
-    "PORT_NAME"  = "${var.vm_name}-${substr(openstack_compute_instance_v2.instance_01.id, 0, 4)}_ssh"
+    "PORT_NAME"  = "${var.vm_name}-${substr(random_uuid.uuid.result, 0, 4)}_ssh"
     "OS_CLOUD"   = var.cloud
   }
   lifecycle_commands {
     create = file("../scripts/generate_port.sh")
     delete = <<-EOF
-      rm -rf "port_${var.vm_name}-${substr(openstack_compute_instance_v2.instance_01.id, 0, 4)}_ssh.json"
+      rm -rf "port_${var.vm_name}-${substr(random_uuid.uuid.result, 0, 4)}_ssh.json"
     EOF
     read   = <<-EOF
-      cat "port_${var.vm_name}-${substr(openstack_compute_instance_v2.instance_01.id, 0, 4)}_ssh.json"
+      cat "port_${var.vm_name}-${substr(random_uuid.uuid.result, 0, 4)}_ssh.json"
     EOF
   }
   working_directory = path.root
@@ -37,15 +42,15 @@ resource "shell_script" "port_http" {
     "OS_CLOUD"   = var.cloud
     "IP_ID"      = data.openstack_networking_floatingip_v2.public.id
     "PORT_COUNT" = 1
-    "PORT_NAME"  = "${var.vm_name}-${substr(openstack_compute_instance_v2.instance_01.id, 0, 4)}_http"
+    "PORT_NAME"  = "${var.vm_name}-${substr(random_uuid.uuid.result, 0, 4)}_http"
   }
   lifecycle_commands {
     create = file("../scripts/generate_port.sh")
     delete = <<-EOF
-      rm -rf "port_${var.vm_name}-${substr(openstack_compute_instance_v2.instance_01.id, 0, 4)}_http.json"
+      rm -rf "port_${var.vm_name}-${substr(random_uuid.uuid.result, 0, 4)}_http.json"
     EOF
     read   = <<-EOF
-      cat "port_${var.vm_name}-${substr(openstack_compute_instance_v2.instance_01.id, 0, 4)}_http.json"
+      cat "port_${var.vm_name}-${substr(random_uuid.uuid.result, 0, 4)}_http.json"
     EOF
   }
   working_directory = path.root

--- a/terraform/modules/single_instance/main.tf
+++ b/terraform/modules/single_instance/main.tf
@@ -23,7 +23,7 @@ resource "openstack_compute_instance_v2" "instance_01" {
   metadata = {
     _SHARE_       = var.nfs_enabled ? module.linux_nfs[0].nfs_path : ""
     _ANSIBLE_URL_ = var.nginx_enabled ? var.playbook_url : ""
-    admin_pass    = local.is_windows ? random_string.winpass[0].result : "N/A"
+    admin_pass    = var.is_windows ? random_string.winpass[0].result : "N/A"
   }
   network {
     port = openstack_networking_port_v2.vm.id

--- a/terraform/modules/single_instance/main.tf
+++ b/terraform/modules/single_instance/main.tf
@@ -1,12 +1,18 @@
+resource "openstack_blockstorage_volume_v3" "root" {
+  name     = "${var.vm_name}-root"
+  size     = local.disk_size
+  image_id = var.image_name
+  enable_online_resize = true
+}
+
 resource "openstack_compute_instance_v2" "instance_01" {
   name        = var.vm_name
   flavor_name = var.flavor_name
   key_pair    = local.access_key
   user_data   = file("../scripts/userdata.sh")
   block_device {
-    uuid                  = data.openstack_images_image_ids_v2.image.ids[0]
-    source_type           = "image"
-    volume_size           = data.openstack_compute_flavor_v2.flavor.disk
+    uuid                  = openstack_blockstorage_volume_v3.root.id
+    source_type           = "volume"
     boot_index            = 0
     destination_type      = "volume"
     delete_on_termination = true

--- a/terraform/modules/single_instance/main.tf
+++ b/terraform/modules/single_instance/main.tf
@@ -3,6 +3,9 @@ resource "openstack_blockstorage_volume_v3" "root" {
   size     = local.disk_size
   image_id = var.image_name
   enable_online_resize = true
+  lifecycle {
+    ignore_changes = [ image_id, source_vol_id]
+  }
 }
 
 resource "openstack_compute_instance_v2" "instance_01" {

--- a/terraform/modules/single_instance/outputs.tf
+++ b/terraform/modules/single_instance/outputs.tf
@@ -28,6 +28,6 @@ locals {
   ssh_user           = contains(keys(local.ssh_users), var.image_name) ? local.ssh_users[var.image_name] : "root"
   private_ssh_string = "SSH: ssh -A ${local.ssh_user}@${openstack_compute_instance_v2.instance_01.network[0].fixed_ip_v4}"
   ssh_string         = var.public ? "SSH: ssh -A -p ${local.ports.ssh} ${local.ssh_user}@${data.openstack_networking_floatingip_v2.public.address}" : local.private_ssh_string
-  windows_string     = "xfreerdp /u:admin /port:${local.ports.ssh} /v:${data.openstack_networking_floatingip_v2.public.address} /p:${random_string.winpass[0].result}"
+  windows_string     = var.is_windows ? "xfreerdp /u:admin /port:${local.ports.ssh} /v:${data.openstack_networking_floatingip_v2.public.address} /p:${random_string.winpass[0].result}" : ""
   http_string        = var.nginx_enabled ? "HTTP: http://${data.openstack_networking_floatingip_v2.public.address}:${local.ports.http}" : ""
 }

--- a/terraform/modules/single_instance/outputs.tf
+++ b/terraform/modules/single_instance/outputs.tf
@@ -6,7 +6,7 @@ output "VM_port" {
 }
 output "Connections" {
   value = trimspace(<<Connections
-${local.is_windows ? local.windows_string : local.ssh_string}
+${var.is_windows ? local.windows_string : local.ssh_string}
 ${local.http_string}
   Connections
   )
@@ -28,6 +28,6 @@ locals {
   ssh_user           = contains(keys(local.ssh_users), var.image_name) ? local.ssh_users[var.image_name] : "root"
   private_ssh_string = "SSH: ssh -A ${local.ssh_user}@${openstack_compute_instance_v2.instance_01.network[0].fixed_ip_v4}"
   ssh_string         = var.public ? "SSH: ssh -A -p ${local.ports.ssh} ${local.ssh_user}@${data.openstack_networking_floatingip_v2.public.address}" : local.private_ssh_string
-  windows_string     = local.is_windows ? "xfreerdp /u:admin /port:${local.ports.ssh} /v:${data.openstack_networking_floatingip_v2.public.address} /p:${random_string.winpass[0].result}" : ""
+  windows_string     = var.is_windows ? "xfreerdp /u:admin /port:${local.ports.ssh} /v:${data.openstack_networking_floatingip_v2.public.address} /p:${random_string.winpass[0].result}" : ""
   http_string        = var.nginx_enabled ? "HTTP: http://${data.openstack_networking_floatingip_v2.public.address}:${local.ports.http}" : ""
 }

--- a/terraform/modules/single_instance/outputs.tf
+++ b/terraform/modules/single_instance/outputs.tf
@@ -28,6 +28,6 @@ locals {
   ssh_user           = contains(keys(local.ssh_users), var.image_name) ? local.ssh_users[var.image_name] : "root"
   private_ssh_string = "SSH: ssh -A ${local.ssh_user}@${openstack_compute_instance_v2.instance_01.network[0].fixed_ip_v4}"
   ssh_string         = var.public ? "SSH: ssh -A -p ${local.ports.ssh} ${local.ssh_user}@${data.openstack_networking_floatingip_v2.public.address}" : local.private_ssh_string
-  windows_string     = "xfreerdp /u:admin /port:${local.ports.ssh} /v:${data.openstack_networking_floatingip_v2.public.address}"
+  windows_string     = "xfreerdp /u:admin /port:${local.ports.ssh} /v:${data.openstack_networking_floatingip_v2.public.address} /p:${random_string.winpass[0].result}"
   http_string        = var.nginx_enabled ? "HTTP: http://${data.openstack_networking_floatingip_v2.public.address}:${local.ports.http}" : ""
 }

--- a/terraform/modules/single_instance/outputs.tf
+++ b/terraform/modules/single_instance/outputs.tf
@@ -28,6 +28,6 @@ locals {
   ssh_user           = contains(keys(local.ssh_users), var.image_name) ? local.ssh_users[var.image_name] : "root"
   private_ssh_string = "SSH: ssh -A ${local.ssh_user}@${openstack_compute_instance_v2.instance_01.network[0].fixed_ip_v4}"
   ssh_string         = var.public ? "SSH: ssh -A -p ${local.ports.ssh} ${local.ssh_user}@${data.openstack_networking_floatingip_v2.public.address}" : local.private_ssh_string
-  windows_string     = var.is_windows ? "xfreerdp /u:admin /port:${local.ports.ssh} /v:${data.openstack_networking_floatingip_v2.public.address} /p:${random_string.winpass[0].result}" : ""
+  windows_string     = local.is_windows ? "xfreerdp /u:admin /port:${local.ports.ssh} /v:${data.openstack_networking_floatingip_v2.public.address} /p:${random_string.winpass[0].result}" : ""
   http_string        = var.nginx_enabled ? "HTTP: http://${data.openstack_networking_floatingip_v2.public.address}:${local.ports.http}" : ""
 }

--- a/terraform/modules/single_instance/outputs.tf
+++ b/terraform/modules/single_instance/outputs.tf
@@ -28,6 +28,6 @@ locals {
   ssh_user           = contains(keys(local.ssh_users), var.image_name) ? local.ssh_users[var.image_name] : "root"
   private_ssh_string = "SSH: ssh -A ${local.ssh_user}@${openstack_compute_instance_v2.instance_01.network[0].fixed_ip_v4}"
   ssh_string         = var.public ? "SSH: ssh -A -p ${local.ports.ssh} ${local.ssh_user}@${data.openstack_networking_floatingip_v2.public.address}" : local.private_ssh_string
-  windows_string     = var.is_windows ? "xfreerdp /u:admin /port:${local.ports.ssh} /v:${data.openstack_networking_floatingip_v2.public.address} /p:${random_string.winpass[0].result}" : ""
+  windows_string     = var.is_windows ? "xfreerdp /dynamic-resolution /u:admin /port:${local.ports.ssh} /v:${data.openstack_networking_floatingip_v2.public.address} /p:${random_string.winpass[0].result}" : ""
   http_string        = var.nginx_enabled ? "HTTP: http://${data.openstack_networking_floatingip_v2.public.address}:${local.ports.http}" : ""
 }

--- a/terraform/modules/single_instance/provider.tf
+++ b/terraform/modules/single_instance/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     openstack = {
       source  = "terraform-provider-openstack/openstack"
-      version = "1.54.1"
+      version = "2.0.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/terraform/modules/single_instance/variable.tf
+++ b/terraform/modules/single_instance/variable.tf
@@ -54,3 +54,6 @@ variable "custom_secgroup_rules" {
 variable "rootdisk_size" {
   default = "default"
 }
+variable "is_windows" {
+  default = false
+}

--- a/terraform/modules/single_instance/variable.tf
+++ b/terraform/modules/single_instance/variable.tf
@@ -55,5 +55,5 @@ variable "rootdisk_size" {
   default = "default"
 }
 variable "is_windows" {
-  default = "default"
+  type = bool
 }

--- a/terraform/modules/single_instance/variable.tf
+++ b/terraform/modules/single_instance/variable.tf
@@ -55,5 +55,5 @@ variable "rootdisk_size" {
   default = "default"
 }
 variable "is_windows" {
-  default = false
+  default = "default"
 }

--- a/terraform/modules/single_instance/variable.tf
+++ b/terraform/modules/single_instance/variable.tf
@@ -51,3 +51,6 @@ variable "custom_secgroup_rules" {
   }))
   default = {}
 }
+variable "rootdisk_size" {
+  default = "default"
+}

--- a/terraform/modules/vsc/provider.tf
+++ b/terraform/modules/vsc/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     openstack = {
       source  = "terraform-provider-openstack/openstack"
-      version = "1.54.1"
+      version = "2.0.0"
     }
     shell = {
       source  = "scottwinkler/shell"


### PR DESCRIPTION
Breaking change: root volume for an instance is now separated to allow it to be live resized. Migration guide will be published in advance. 

Breaking change:  Port assign script is more resilient against variable changes (also included in migration guide)

Other changes:
* Can force windows-style configuration with `is_windows` var
* Windows output now shows password in the command
