### PR TITLE
enable online resize on custom volumes as well

### DIFF
--- a/terraform/modules/single_instance/volumes.tf
+++ b/terraform/modules/single_instance/volumes.tf
@@ -2,6 +2,7 @@ resource "openstack_blockstorage_volume_v3" "custom_volume" {
   for_each = var.volumes
   name = each.key
   size = each.value.size
+  enable_online_resize = true
 }
 
 resource "openstack_compute_volume_attach_v2" "custom_volume" {


### PR DESCRIPTION
Fix an oversight that allows the custom volumes attached to a VM to be resized as well.

Not a breaking change (for once)