### PR TITLE
Project and cloud detection

### DIFF
--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -1,0 +1,3 @@
+{
+    "cloud" : "openstack"
+}

--- a/terraform/environment/variable.tf
+++ b/terraform/environment/variable.tf
@@ -1,3 +1,3 @@
+# Do not change this file, change terraform.tfvars.json
 variable "cloud" {
-  default = "openstack"
 }

--- a/terraform/modules/multi_instance/main.tf
+++ b/terraform/modules/multi_instance/main.tf
@@ -4,12 +4,11 @@ module "main" {
   image_name    = var.public_image
   flavor_name   = var.public_flavor
   nginx_enabled = var.public_nginx_enabled
-  cloud         = var.cloud
   project_name  = var.project_name
   access_key    = var.access_key
   vsc_enabled   = var.public_vsc_enabled
   playbook_url  = var.playbook_url
-  is_windows = false
+  is_windows    = false
 }
 module "private" {
   count        = var.private_count
@@ -17,11 +16,10 @@ module "private" {
   vm_name      = "${var.cluster_name}-private-${count.index}"
   image_name   = local.private_image
   flavor_name  = local.private_flavor
-  cloud        = var.cloud
   project_name = var.project_name
   access_key   = var.access_key
   public       = false
-  is_windows = false
+  is_windows   = false
 }
 output "main" {
   value = module.main.Connections

--- a/terraform/modules/single_instance/data.tf
+++ b/terraform/modules/single_instance/data.tf
@@ -7,6 +7,7 @@ locals {
   }
   ssh_internal_port = var.is_windows ? 3389 : 22
   project_name      = data.openstack_identity_project_v3.project.name
+  cloud             = jsondecode(file("${path.cwd}/terraform.tfvars.json"))["cloud"]
   access_key        = var.access_key == "default" ? data.shell_script.access_key.output["Name"] : var.access_key
   disk_var          = var.rootdisk_size == "default" ? data.openstack_compute_flavor_v2.flavor.disk : var.rootdisk_size
   disk_size         = var.is_windows ? max(local.disk_var,60) : local.disk_var
@@ -21,7 +22,7 @@ resource "shell_script" "port_ssh" {
     "IP_ID"      = data.openstack_networking_floatingip_v2.public.id
     "PORT_COUNT" = 1
     "PORT_NAME"  = "${var.vm_name}-${substr(random_uuid.uuid.result, 0, 4)}_ssh"
-    "OS_CLOUD"   = var.cloud
+    "OS_CLOUD"   = local.cloud
   }
   lifecycle_commands {
     create = file("../scripts/generate_port.sh")
@@ -38,7 +39,7 @@ resource "shell_script" "port_ssh" {
 resource "shell_script" "port_http" {
   count = var.nginx_enabled ? 1 : 0
   environment = {
-    "OS_CLOUD"   = var.cloud
+    "OS_CLOUD"   = local.cloud
     "IP_ID"      = data.openstack_networking_floatingip_v2.public.id
     "PORT_COUNT" = 1
     "PORT_NAME"  = "${var.vm_name}-${substr(random_uuid.uuid.result, 0, 4)}_http"
@@ -57,13 +58,13 @@ resource "shell_script" "port_http" {
 }
 data "openstack_identity_auth_scope_v3" "scope" {
   name = "scope"
-  }
+}
 data "openstack_identity_project_v3" "project" {
   name = data.openstack_identity_auth_scope_v3.scope.project_name
 }
 data "shell_script" "access_key" {
   environment = {
-    OS_CLOUD = var.cloud
+    OS_CLOUD = local.cloud
   }
   lifecycle_commands {
     read = <<EOF

--- a/terraform/modules/single_instance/main.tf
+++ b/terraform/modules/single_instance/main.tf
@@ -73,7 +73,7 @@ module "linux_nfs" {
   project_name       = local.project_name
   security_group_ids = ["${openstack_networking_secgroup_v2.secgroup.id}"]
   instance_id        = openstack_compute_instance_v2.instance_01.id
-  cloud              = var.cloud
+  cloud              = local.cloud
 }
 module "linux_vsc" {
   count             = var.vsc_enabled ? 1 : 0
@@ -81,5 +81,5 @@ module "linux_vsc" {
   instance_id       = openstack_compute_instance_v2.instance_01.id
   security_group_id = openstack_networking_secgroup_v2.secgroup.id
   project_name      = local.project_name
-  cloud             = var.cloud
+  cloud             = local.cloud
 }

--- a/terraform/modules/single_instance/variable.tf
+++ b/terraform/modules/single_instance/variable.tf
@@ -29,9 +29,6 @@ variable "project_name" {
 variable "nfs_size" {
   default = 10
 }
-variable "cloud" {
-  default = "openstack"
-}
 variable "public" {
   default = true
   type    = bool


### PR DESCRIPTION
* Users with multiple projects should now have the correct project selected consistently
* Users that wish to use a cloud different from `openstack` now only have to edit `tfvars.json`