### PR TITLE
Fix nginx install for all distros

### DIFF
--- a/heat/playbooks/install_nginx.yaml
+++ b/heat/playbooks/install_nginx.yaml
@@ -4,7 +4,7 @@
   hosts: localhost
   tasks:
    - name: Install Nginx
-     package: name=nginx state=installed
+     package: name=nginx state=present
      notify:
       - Start Nginx
   handlers:


### PR DESCRIPTION
`installed` is a non-standard ansible parameter that not every package manager module supports and seems to have been removed for Ubuntu. This change ensures nginx installs regardless of distro on old and new versions of Ansible