### PR TITLE
Port forwarding

### DIFF
--- a/terraform/environment/custom_secgroup.example
+++ b/terraform/environment/custom_secgroup.example
@@ -1,14 +1,18 @@
-module "Prometheus" {
+module "MyVMWithPorts" {
   source        = "../modules/single_instance"
   vm_name       = "MyVM"
-  image_name    = "Rocky-8"
+  image_name    = "Rocky-9"
   flavor_name   = "CPUv1.medium"
   custom_secgroup_rules = { 
     prometheus = {
       port = 9090
       protocol = "tcp"
       remote_ip_prefix = "0.0.0.0/0"
+      expose   = false # If set to true, will expose this port to the internet through a random external port. Use with caution. 
     }
   }
   is_windows=false
+}
+output "MyVMWithPorts" {
+  value = module.MyVMWithPorts.Connections
 }

--- a/terraform/modules/nfs/data.tf
+++ b/terraform/modules/nfs/data.tf
@@ -1,5 +1,5 @@
 data "openstack_networking_network_v2" "nfs" {
-  name = "${var.project_name}_nfs"
+  name = "${var.project_name}_nfs_vxlan"
 }
 data "openstack_networking_subnet_ids_v2" "nfs" {
   network_id = data.openstack_networking_network_v2.nfs.id

--- a/terraform/modules/single_instance/custom_secgroup.tf
+++ b/terraform/modules/single_instance/custom_secgroup.tf
@@ -10,3 +10,54 @@ resource openstack_networking_secgroup_rule_v2 "custom" {
   security_group_id = openstack_networking_secgroup_v2.secgroup.id
   description = "${data.openstack_identity_auth_scope_v3.scope.user_name}-${var.vm_name}-${each.key}"
 }
+resource "shell_script" "custom_portforward" {
+  for_each =  {
+    for k, v in var.custom_secgroup_rules:  k => v
+    if var.custom_secgroup_rules[k].expose == true
+  }
+  environment = {
+    "IP_ID"      = data.openstack_networking_floatingip_v2.public.id
+    "PORT_COUNT" = 1
+    "PORT_NAME"  = "${var.vm_name}-${substr(random_uuid.uuid.result, 0, 4)}_${each.key}"
+    "OS_CLOUD"   = local.cloud
+  }
+  lifecycle_commands {
+    create = file("../scripts/generate_port.sh")
+    delete = <<-EOF
+      rm -rf "port_${var.vm_name}-${substr(random_uuid.uuid.result, 0, 4)}_${each.key}.json"
+    EOF
+    read   = <<-EOF
+      cat "port_${var.vm_name}-${substr(random_uuid.uuid.result, 0, 4)}_${each.key}.json"
+    EOF
+  }
+  working_directory = path.root
+  interpreter       = ["/bin/bash", "-c"]
+}
+resource "openstack_networking_portforwarding_v2" "custom" {
+  for_each =  {
+    for k, v in var.custom_secgroup_rules:  k => merge(v,{external_port = jsondecode(shell_script.custom_portforward[k].output["ports"])[0] })
+    if var.custom_secgroup_rules[k].expose == true
+  }
+  floatingip_id       = data.openstack_networking_floatingip_v2.public.id
+  external_port       = each.value.external_port
+  internal_port       = each.value.port
+  internal_port_id    = openstack_networking_port_v2.vm.id
+  internal_ip_address = openstack_networking_port_v2.vm.all_fixed_ips[0]
+  protocol            = "tcp"
+  lifecycle {
+    precondition {
+      condition     = var.public
+      error_message = ("Cant enable forward on a private instance!")
+    }
+    replace_triggered_by = [ openstack_networking_secgroup_rule_v2.custom[each.key] ]
+  }
+  description = "${data.openstack_identity_auth_scope_v3.scope.user_name}-${var.vm_name}-${each.key}"
+}
+locals {
+  custom_ports=trimspace(<<PORTS
+%{for k,v in openstack_networking_portforwarding_v2.custom ~}
+${k} ${v.internal_port} -> ${data.openstack_networking_floatingip_v2.public.address}:${v.external_port}
+%{endfor}
+PORTS
+  )
+}

--- a/terraform/modules/single_instance/outputs.tf
+++ b/terraform/modules/single_instance/outputs.tf
@@ -8,8 +8,12 @@ output "Connections" {
   value = trimspace(<<Connections
 ${var.is_windows ? local.windows_string : local.ssh_string}
 ${local.http_string}
+${length(openstack_networking_portforwarding_v2.custom) > 0 ? local.custom_ports : ""}
   Connections
   )
+}
+output "ports" {
+  value = local.custom_ports
 }
 output "Name" {
   value = openstack_compute_instance_v2.instance_01.name

--- a/terraform/modules/single_instance/variable.tf
+++ b/terraform/modules/single_instance/variable.tf
@@ -45,6 +45,7 @@ variable "custom_secgroup_rules" {
     port = number
     remote_ip_prefix = string
     protocol = string
+    expose = optional(bool,false)
   }))
   default = {}
 }


### PR DESCRIPTION
* Adds an `expose` variable that lets users expose a port in their security group to the internet
* Adds output showing which ports are exposed and what the external port is
* Fixes the security group rules template
* Fixes the NFS network name

This should be backwards compatible and shouldn't cause any issues if users `git stash && git pull && git stash apply`. 