### PR TITLE
Restore nginx playbook to fix old existing template deployments

### DIFF
--- a/heat/playbooks/install_nginx.yaml
+++ b/heat/playbooks/install_nginx.yaml
@@ -1,0 +1,12 @@
+---
+- name: Install and run Nginx
+  connection: local
+  hosts: localhost
+  tasks:
+   - name: Install Nginx
+     package: name=nginx state=present
+     notify:
+      - Start Nginx
+  handlers:
+   - name: Start Nginx
+     service: name=nginx state=started


### PR DESCRIPTION
Older templates attempt to download this file straight from github, which now fails because the file is no longer there.