### PR TITLE
Fix validation error when there are no custom secgroup rules

### DIFF
--- a/terraform/modules/single_instance/variable.tf
+++ b/terraform/modules/single_instance/variable.tf
@@ -67,7 +67,7 @@ variable "custom_secgroup_rules" {
   default = {}
   validation {
     condition = (
-      anytrue(
+      length(var.custom_secgroup_rules) == 0 ? true : anytrue(
         [for v in var.custom_secgroup_rules :
           v.external_port == null ? true : (v.external_port >= local.ugent_port_range.min &&
           v.external_port <= local.ugent_port_range.max)


### PR DESCRIPTION
Fixes a bug that prevents the default simple example from working