### PR TITLE
Fix NFS access ACL

### DIFF
--- a/terraform/modules/nfs_share/data.tf
+++ b/terraform/modules/nfs_share/data.tf
@@ -14,3 +14,6 @@ data "openstack_networking_subnet_v2" "nfs" {
   name = "${data.openstack_identity_project_v3.project.name}_nfs_vxlan_pool"
 }
 
+data "openstack_networking_router_v2" "nfs" {
+  name = "NAT_nfs_vxlan_${data.openstack_identity_project_v3.project.name}"
+}

--- a/terraform/modules/nfs_share/main.tf
+++ b/terraform/modules/nfs_share/main.tf
@@ -9,7 +9,7 @@ resource "openstack_sharedfilesystem_share_access_v2" "default" {
   count = length(var.access_rules) == 0 ? 1 : 0
   share_id     = openstack_sharedfilesystem_share_v2.share.id
   access_type  = "ip"
-  access_to    = data.openstack_networking_subnet_v2.nfs.cidr
+  access_to    = data.openstack_networking_router_v2.nfs.external_fixed_ip[0].ip_address
   access_level = "rw"
 }
 resource "openstack_sharedfilesystem_share_access_v2" "rules" {


### PR DESCRIPTION
Ganesha sees the router IP, not the VM IP, because of NAT. This will make it so that by default, the nfs share can only be accessed from any VM in the NFS network of the project. 