### PR TITLE
Ignore powerstate

### DIFF
--- a/terraform/modules/single_instance/ansible.tf
+++ b/terraform/modules/single_instance/ansible.tf
@@ -8,7 +8,7 @@ locals {
 }
 resource "null_resource" "testconnection" {
   count = local.scripts_enabled ? 1 : 0
-  depends_on = [ openstack_compute_instance_v2.instance_01 ]
+  depends_on = [ openstack_compute_instance_v2.instance_01, openstack_networking_portforwarding_v2.ssh ]
   triggers = {
     user = local.ssh_user
     port = local.ports.ssh

--- a/terraform/modules/single_instance/main.tf
+++ b/terraform/modules/single_instance/main.tf
@@ -33,8 +33,9 @@ resource "openstack_compute_instance_v2" "instance_01" {
   tags = [ data.openstack_identity_auth_scope_v3.scope.user_name, var.vm_name ]
   lifecycle {
     # Otherwise a script update to userdata will trigger a recreate
-    ignore_changes = [ user_data ]
+    ignore_changes = [ user_data,power_state ]
   }
+  power_state = "active"
 }
 
 resource "openstack_networking_secgroup_v2" "secgroup" {


### PR DESCRIPTION
This will let users turn off their VMs without Terraform turning them back on again.